### PR TITLE
Fixed parsing of media_types including dots

### DIFF
--- a/lib/rack/accept/header.rb
+++ b/lib/rack/accept/header.rb
@@ -38,7 +38,7 @@ module Rack::Accept
     # subtype, and 3) the media type parameters. An empty array is returned if
     # no match can be made.
     def parse_media_type(media_type)
-      m = media_type.to_s.match(/^([a-z*]+)\/([a-z*\-\.]+)(?:;([a-z0-9=;]+))?$/)
+      m = media_type.to_s.match(/^([a-z*]+)\/([a-z0-9*\-.+]+)(?:;([a-z0-9=;]+))?$/)
       m ? [m[1], m[2], m[3] || ''] : []
     end
     module_function :parse_media_type

--- a/test/media_type_test.rb
+++ b/test/media_type_test.rb
@@ -47,6 +47,9 @@ class MediaTypeTest < Test::Unit::TestCase
     m = M.new("application/vnd.ms-excel")
     assert_equal(nil, m.best_of(%w< application/vnd.ms-powerpoint >))
 
+    m = M.new("application/vnd.api-v1+json")
+    assert_equal(false, m.accept?("application/vnd.api-v2+json"))
+
     v1, v2 = "application/vnd.api-v1+json", "application/vnd.api-v2+json"
     m = M.new("#{v1},#{v2}")
     assert_equal(v1, m.best_of([v1, v2]))


### PR DESCRIPTION
There was a bug in media_types parsing for media types including a dot. Here are examples of valid media types which were not recognized properly by rack-accept:

audio/vnd.rn-realaudio
application/vnd.mozilla.xul+xml

Examples taken from http://en.wikipedia.org/wiki/Internet_media_type
I had to change the regexp in parse_media_type to fix it, I've added a test for it, please merge.
