### PR TITLE
Use case insensitive matching for tokens

### DIFF
--- a/lib/rack/accept/header.rb
+++ b/lib/rack/accept/header.rb
@@ -14,7 +14,7 @@ module Rack::Accept
         m = /^([^\s,]+?)(?:\s*;\s*q\s*=\s*(\d+(?:\.\d+)?))?$/.match(part)
 
         if m
-          qvalues[m[1]] = normalize_qvalue((m[2] || 1).to_f)
+          qvalues[m[1].downcase] = normalize_qvalue((m[2] || 1).to_f)
         else
           raise "Invalid header value: #{part.inspect}"
         end

--- a/test/language_test.rb
+++ b/test/language_test.rb
@@ -31,5 +31,11 @@ class LanguageTest < Test::Unit::TestCase
     assert_equal('en', l.best_of(%w< en da >))
     assert_equal('en-us', l.best_of(%w< en-us en-au >))
     assert_equal(nil, l.best_of(%w< da >))
+
+    l = L.new('en;q=0.5, en-GB, fr-CA')
+    assert_equal('en-gb', l.best_of(%w< en en-gb >))
+
+    l = L.new('en-gb;q=0.5, EN, fr-CA')
+    assert_equal('en', l.best_of(%w< en en-gb >))
   end
 end

--- a/test/media_type_test.rb
+++ b/test/media_type_test.rb
@@ -36,6 +36,10 @@ class MediaTypeTest < Test::Unit::TestCase
     m = M.new('text/*')
     assert_equal('text/html', m.best_of(%w< text/html text/xml >))
     assert_equal('text/xml', m.best_of(%w< text/xml text/html >))
+
+    m = M.new('TEXT/*')
+    assert_equal('text/html', m.best_of(%w< text/html text/xml >))
+    assert_equal('text/xml', m.best_of(%w< text/xml text/html >))
   end
 
   def test_extension


### PR DESCRIPTION
As reported by @saraogi in #6, [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt) states that all tokens (languages, content types, encoding) are case-insensitive.

I included the code and some basic tests.
