### PR TITLE
Add support for first-level language matching

### DIFF
--- a/lib/rack/accept/language.rb
+++ b/lib/rack/accept/language.rb
@@ -6,6 +6,7 @@ module Rack::Accept
   # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
   class Language
     include Header
+    attr_writer :first_level_match
 
     # The name of this header.
     def name
@@ -24,6 +25,7 @@ module Rack::Accept
     # +language+, ordered by precedence.
     def matches(language)
       values.select {|v|
+        v = v.match(/^(.+?)-/) ? $1 : v if @first_level_match
         v == language || v == '*' || (language.match(/^(.+?)-/) && v == $1)
       }.sort {|a, b|
         # "*" gets least precedence, any others are compared based on length.

--- a/test/language_test.rb
+++ b/test/language_test.rb
@@ -31,5 +31,17 @@ class LanguageTest < Test::Unit::TestCase
     assert_equal('en', l.best_of(%w< en da >))
     assert_equal('en-us', l.best_of(%w< en-us en-au >))
     assert_equal(nil, l.best_of(%w< da >))
+
+    l = L.new('en;q=0.5, en-GB, fr-CA')
+    assert_equal('en-gb', l.best_of(%w< en en-gb >))
+
+    l = L.new('en-gb;q=0.5, EN, fr-CA')
+    assert_equal('en', l.best_of(%w< en en-gb >))
+
+    l = L.new('en;q=0.5, fr-ca')
+    assert_equal('en', l.best_of(%w< en fr >))
+
+    l.first_level_match = true
+    assert_equal('fr', l.best_of(%w< en fr >))
   end
 end


### PR DESCRIPTION
This allows us to only declare first-level languages we want to match against and still get matchs from languge pairs (such as `fr-ca` or `en-US`). This is better summarized using an example:

``` ruby
get "/" do
  accept = env['rack-accept.request'] # "en;q=0.5, fr-ca"
  accept.best_language(%w{fr en}) # => "en"
end

get "/foo" do
  accept = env['rack-accept.request'] # "en;q=0.5, fr-ca"
  accept.first_level_match = true
  accept.best_language(%w{fr en}) # => "fr"
end
```
