### PR TITLE
[bugfix] Allow all characters in mediatype name per RFC6838 - most notably the underscore

### DIFF
--- a/lib/rack/accept/header.rb
+++ b/lib/rack/accept/header.rb
@@ -38,7 +38,8 @@ module Rack::Accept
     # subtype, and 3) the media type parameters. An empty array is returned if
     # no match can be made.
     def parse_media_type(media_type)
-      m = media_type.to_s.match(/^([a-z*]+)\/([a-z0-9*\-.+]+)(?:;([a-z0-9=;]+))?$/)
+      # see http://tools.ietf.org/html/rfc6838#section-4.2 for allowed characters in media type names
+      m = media_type.to_s.match(/^([a-z*]+)\/([a-z0-9*\&\^\-_#\$!.+]+)(?:;([a-z0-9=;]+))?$/)
       m ? [m[1], m[2], m[3] || ''] : []
     end
     module_function :parse_media_type

--- a/test/header_test.rb
+++ b/test/header_test.rb
@@ -44,7 +44,7 @@ class HeaderTest < Test::Unit::TestCase
     assert_equal(['text', 'html', 'level=1'], H.parse_media_type('text/html;level=1'))
     assert_equal(['text', 'html', 'level=1;answer=42'], H.parse_media_type('text/html;level=1;answer=42'))
     assert_equal(['text', 'x-dvi', ''], H.parse_media_type('text/x-dvi'))
-    assert_equal(['application', 'vnd.usertesting.available_sessions-v1+json', ''], H.parse_media_type('application/vnd.usertesting.available_sessions-v1+json'))
+    assert_equal(['application', 'vnd.vendorname.available_foos-v1+json', ''], H.parse_media_type('application/vnd.vendorname.available_foos-v1+json'))
   end
 
   def test_parse_range_params

--- a/test/header_test.rb
+++ b/test/header_test.rb
@@ -44,6 +44,7 @@ class HeaderTest < Test::Unit::TestCase
     assert_equal(['text', 'html', 'level=1'], H.parse_media_type('text/html;level=1'))
     assert_equal(['text', 'html', 'level=1;answer=42'], H.parse_media_type('text/html;level=1;answer=42'))
     assert_equal(['text', 'x-dvi', ''], H.parse_media_type('text/x-dvi'))
+    assert_equal(['application', 'vnd.usertesting.available_sessions-v1+json', ''], H.parse_media_type('application/vnd.usertesting.available_sessions-v1+json'))
   end
 
   def test_parse_range_params


### PR DESCRIPTION
I have updated the `parse_media_type` method to match additional characters allowed in media type names per RFC6838.

```
Type and subtype names MUST conform to the following ABNF:

     type-name = restricted-name
     subtype-name = restricted-name

     restricted-name = restricted-name-first *126restricted-name-chars
     restricted-name-first  = ALPHA / DIGIT
     restricted-name-chars  = ALPHA / DIGIT / "!" / "#" /
                              "$" / "&" / "-" / "^" / "_"
     restricted-name-chars =/ "." ; Characters before first dot always
                                  ; specify a facet name
     restricted-name-chars =/ "+" ; Characters after last plus always
                                  ; specify a structured syntax suffix
```
