### PR TITLE
Add MIT licence to the gemspec

### DIFF
--- a/rack-accept.gemspec
+++ b/rack-accept.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
 
   s.author = 'Michael Jackson'
   s.email = 'mjijackson@gmail.com'
+  s.license = 'MIT'
 
   s.require_paths = %w< lib >
 


### PR DESCRIPTION
### Description
I've noticed that even though the license is present in README, there is no mention of any license in `gemspec`; therefore, it's not reflected in rubygems.org.

This PR is dedicated to adding an MIT license to the gemspec